### PR TITLE
Jm/lic check

### DIFF
--- a/Templates/Pipeline.yml
+++ b/Templates/Pipeline.yml
@@ -152,13 +152,13 @@ stages:
         Write-Host -Object ($GetBcArtifactUrlParameters | ConvertTo-Json -Depth 1)
 
         # Exit early because BC22 builds do not work because the license error.
-        if ($GetBcArtifactUrlParameters.Select -eq 'NextMajor') {
-          Write-Host -Object 'Exiting early until BC22 builds are fixed.'
-          if ([datetime]::Now -ge [datetime]'2023-01-01') {
-            throw 'Are BC22 builds finally fixed?'
-          }
-          exit
-        }
+       #if ($GetBcArtifactUrlParameters.Select -eq 'NextMajor') {
+          #Write-Host -Object 'Exiting early until BC22 builds are fixed.'
+          #if ([datetime]::Now -ge [datetime]'2023-01-01') {
+          #  throw 'Are BC22 builds finally fixed?'
+          #}
+          #exit
+        #}
 
         $BcArtifactUrl = Get-BCArtifactUrl @GetBcArtifactUrlParameters
         

--- a/Templates/Pipeline.yml
+++ b/Templates/Pipeline.yml
@@ -151,14 +151,7 @@ stages:
         Write-Host
         Write-Host -Object ($GetBcArtifactUrlParameters | ConvertTo-Json -Depth 1)
 
-        # Exit early because BC22 builds do not work because the license error.
-       #if ($GetBcArtifactUrlParameters.Select -eq 'NextMajor') {
-          #Write-Host -Object 'Exiting early until BC22 builds are fixed.'
-          #if ([datetime]::Now -ge [datetime]'2023-01-01') {
-          #  throw 'Are BC22 builds finally fixed?'
-          #}
-          #exit
-        #}
+
 
         $BcArtifactUrl = Get-BCArtifactUrl @GetBcArtifactUrlParameters
         

--- a/Templates/Pipeline.yml
+++ b/Templates/Pipeline.yml
@@ -268,7 +268,7 @@ stages:
         Write-Host -Object "##vso[task.setvariable variable=ContainerName;]$Global:ContainerName"
         $LicensePath = $(
           ($PlatformVersion.Major)..12 |
-          ForEach-Object -Process { "\\filestorage\Projects\DevOps\!Pipeline\Licenses\BC$_.flf" } |
+          ForEach-Object -Process { "\\filestorage\Projects\DevOps\!Pipeline\Licenses\BC$_.bclicense" } |
           Resolve-Path |
           Select-Object -First 1 -ExpandProperty ProviderPath
         )


### PR DESCRIPTION
Replaced .flf to .bclicense
Removed warning 'Exit early because BC22 builds do not work because the license error.'